### PR TITLE
Fix typo in audio extraction function name

### DIFF
--- a/REMWaste_task/audio_to_text.py
+++ b/REMWaste_task/audio_to_text.py
@@ -5,7 +5,7 @@ from langchain_community.document_loaders.generic import GenericLoader
 from langchain_community.document_loaders.parsers import OpenAIWhisperParser
 
 
-def extract_audio_and_covert_to_text(url: str, audio_save_path="./youtube_audios/"):
+def extract_audio_and_convert_to_text(url: str, audio_save_path="./youtube_audios/"):
 
     # YouTube URL
     urls = [url]

--- a/REMWaste_task/modules.ipynb
+++ b/REMWaste_task/modules.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from audio_to_text import extract_audio_and_covert_to_text\n",
+    "from audio_to_text import extract_audio_and_convert_to_text\n",
     "\n",
     "from state import GraphState\n",
     "\n",
@@ -92,7 +92,7 @@
     }
    ],
    "source": [
-    "text = extract_audio_and_covert_to_text(youtube_url, save_path)"
+    "text = extract_audio_and_convert_to_text(youtube_url, save_path)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- rename `extract_audio_and_covert_to_text` to `extract_audio_and_convert_to_text`
- update references in `modules.ipynb`

## Testing
- `python -m py_compile REMWaste_task/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684205e0fd308329a9b1fad5e3400df0