### PR TITLE
Fix accent grade type

### DIFF
--- a/REMWaste_task/state.py
+++ b/REMWaste_task/state.py
@@ -11,7 +11,7 @@ class GraphState(TypedDict):
         question: user input
         documents: List of document
         accent_type: Classification of the accent
-        accent_grade: List of Englis Accent grade
+        accent_grade: Numeric confidence score representing the strength of the English accent
         generation: LLM generated answer
     """
 
@@ -20,5 +20,5 @@ class GraphState(TypedDict):
     accent_type: Annotated[
         str, "Classification of the accent (e.g., British, American, Australian, etc.)"
     ]
-    accent_grade: Annotated[List[str], "List of Englis Accent grade"]
+    accent_grade: Annotated[float, "English accent confidence score"]
     generation: Annotated[str, "LLM generated answer"]


### PR DESCRIPTION
## Summary
- fix GraphState comment and annotation for `accent_grade`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68420503b4048329ac040fbaccb2d676