### PR TITLE
Add text fallback loading for FAISS index

### DIFF
--- a/REMWaste_task/modules.ipynb
+++ b/REMWaste_task/modules.ipynb
@@ -106,7 +106,7 @@
     "model_name = \"text-embedding-3-small\"\n",
     "\n",
     "# Build Vector DB\n",
-    "db = build_vectordb(text, cached_dir, db_index, model_name)\n",
+    "db = build_vectordb(cached_dir, db_index, text, model_name)\n",
     "\n",
     "# initialize retriever\n",
     "retriever = db.as_retriever(search_kwargs={\"k\": 30})\n",

--- a/REMWaste_task/vectordb.py
+++ b/REMWaste_task/vectordb.py
@@ -24,50 +24,75 @@ def get_cached_embedder(
 
 
 def build_vectordb(
-    texts,
     cache_dir: str,
     db_index: str,
+    texts: str | list[str] | None = None,
     model_name: str = "text-embedding-3-small",
     chunk_size: int = 1500,
     chunk_overlap: int = 150,
 ) -> FAISS:
+    """Create or load a FAISS vector store.
+
+    Parameters
+    ----------
+    cache_dir : str
+        Directory to store embedding cache.
+    db_index : str
+        Directory to load or save the FAISS index.
+    texts : str | list[str] | None, optional
+        Input text(s) to index. When ``db_index`` already exists and this
+        argument is ``None``, the function will attempt to read the text from
+        ``db_index/raw_text.txt`` if present.
+    model_name : str, optional
+        Name of the OpenAI embedding model to use.
+    chunk_size, chunk_overlap : int, optional
+        Parameters for document chunking.
+
+    Returns
+    -------
+    FAISS
+        Loaded or newly created FAISS vector store.
     """
-    1) texts: A single string or a list of strings
-    2) cache_dir: Directory to store embedding cache
-    3) db_index: Directory to load or save the FAISS index
-    4) model_name: Name of the OpenAI embedding model to use
-    5) chunk_size / chunk_overlap: Parameters for document chunking
 
-    Returns: A FAISS vector store (either loaded or newly created)
-    """
-    # ============= 1. Split Text =============
-    splitter = RecursiveCharacterTextSplitter(
-        chunk_size=chunk_size, chunk_overlap=chunk_overlap
-    )
-
-    split_docs = splitter.split_text(texts)
-
-    # ============= 2. Embedding =============
     embedder = get_cached_embedder(cache_dir, model_name)
 
-    # ============= 3.Check whether the index is loaded =============
+    # ===== 1. Load existing index if present =====
     if os.path.isdir(db_index):
         db = FAISS.load_local(
             db_index,
             embedder,
             allow_dangerous_deserialization=True,
         )
+
+        if texts is None:
+            raw_file = os.path.join(db_index, "raw_text.txt")
+            if os.path.isfile(raw_file):
+                with open(raw_file, "r", encoding="utf-8") as f:
+                    texts = f.read()
+
         return db
 
-    # ============= 4. Create and save the index=============
-    faiss_db = FAISS.from_texts(split_docs, embedder)
+    # ===== 2. Build a new index =====
+    if texts is None:
+        raise ValueError("texts must be provided when creating a new index")
+
     os.makedirs(db_index, exist_ok=True)
+
+    raw_file = os.path.join(db_index, "raw_text.txt")
+    joined = "\n".join(texts) if isinstance(texts, list) else texts
+    with open(raw_file, "w", encoding="utf-8") as f:
+        f.write(joined)
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size, chunk_overlap=chunk_overlap
+    )
+    split_docs = splitter.split_text(joined)
+
+    faiss_db = FAISS.from_texts(split_docs, embedder)
     faiss_db.save_local(db_index)
 
-    db = FAISS.load_local(
+    return FAISS.load_local(
         db_index,
         embedder,
         allow_dangerous_deserialization=True,
     )
-
-    return db


### PR DESCRIPTION
## Summary
- enhance `build_vectordb` to optionally load saved text when index exists
- adjust Jupyter notebook call for new argument order

## Testing
- `python -m py_compile REMWaste_task/vectordb.py`
- `python -m py_compile REMWaste_task/*.py`
- `python -m json.tool REMWaste_task/modules.ipynb > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_684202e679648329aa257bafac42789c